### PR TITLE
Add blog post on IceNet forecasts on RAMADDA

### DIFF
--- a/src/data/post/oct25-icenet-forecasts-published.mdx
+++ b/src/data/post/oct25-icenet-forecasts-published.mdx
@@ -1,0 +1,79 @@
+---
+publishDate: 2025-10-07T00:00:00Z
+author: Bryn Noel Ubald
+title: Operational IceNet Forecasts Now Publicly Accessible!
+excerpt: IceNet forecasts are now available on the PDC's RAMADDA platform.
+image: https://images.unsplash.com/photo-1598439210625-5067c578f3f6?q=80&w=2072&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D
+category: Article
+tags:
+  - news
+metadata:
+  canonical: https://astrowind.vercel.app/astrowind-template-in-depth
+---
+
+import DListItem from '~/components/ui/DListItem.astro';
+import ToggleTheme from '~/components/common/ToggleTheme.astro';
+
+We are thrilled to announce that the Polar Data Centre's [RAMADDA data repository](https://ramadda.data.bas.ac.uk/repository/a/icenet-daily-sea-ice-forecasts) is now home to daily IceNet forecasts! This platform now enables a wide range of end-users to access these forecasts. With automated inclusion of latest forecasts as they are generated on a daily basis.
+
+Use-cases could involve:
+
+- Empowering researchers/students in research
+- Informing policymakers
+- Navigation of ships in polar regions
+- Environmental monitoring
+
+**Please note that IceNet forecasts are highly experimental and is a research codebase**
+
+<a href="https://ramadda.data.bas.ac.uk/repository/a/icenet-daily-sea-ice-forecasts" target="_blank">Explore IceNet on RAMADDA</a>
+
+### Why This Matters
+Sea ice plays a critical role in global climate systems, influencing ocean currents, wildlife habitats, and human activities like shipping. IceNet forecasts can enable users to visualise and analyse daily forecasts of sea-ice.
+
+### Join Us in Exploring the Polar Regions
+Whether you're a scientist, student, or simply curious about Earth's changing environment, we invite you to dive into IceNet forecasts via RAMADDA.
+
+
+## Model definition
+
+The current release of the forecasts contain daily sea ice forecasts across the northern and southern hemispheres (via two separate models) derived from OSI-SAF 25km<sup>2</sup> grid used as ground truth. They are labelled as `exp23_north` and `exp23_south`, and forecast up to 93 days ahead, with a roughly 5-7 day delay depending on ERA5 data release cycle.
+
+These models were trained using [icenet v0.2.4_dev](https://pypi.org/project/icenet/0.2.4/) on the British Antarctic Survey's internal HPC (BAS HPC) with the following input variables:
+
+* ERA5
+  * psl
+  * ta500
+  * tas
+  * tos
+  * uas
+  * vas
+  * zg250
+  * zg500
+* OSI-SAF
+  * siconca (also, the target variable)
+
+### Train splits
+The date ranges used for training are as follows:
+* 1994-01-01 to 1995-12-31
+* 2006-01-01 to 2008-12-31
+* 2011-01-01 to 2013-12-31
+
+### Validation splits
+The date ranges used for validation are as follows:
+* 2009-07-01 to 2010-06-30
+
+### Prediction
+
+The predictions are generated using [icenet v0.2.9](https://pypi.org/project/icenet/0.2.9/), also on BAS HPC.
+
+### License
+
+Unless otherwise stated, all content is owned by British Antarctic Survey and The Alan Turing Institute 2025, and made available via the [Open Government License](https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/) which is compatible with the [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/).
+
+## Future
+
+In the future, RAMADDA will also host IceNet forecasts from different models:
+- AMSR2 sea-ice based predictions.
+- Monthly predictions, up to 6 months ahead.
+- Fine-tuned models combining OSI-SAF and AMSR2 training.
+

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -61,7 +61,7 @@ export const headerData = {
       ],
     },
   ],
-  actions: [{ text: 'Documentation', href: 'docs/', target: '_blank' }],
+  actions: [{ text: 'Documentation', href: '/docs/', target: '_blank' }],
 };
 
 export const footerData = {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -86,43 +86,63 @@ const images = import.meta.glob<{ default: ImageMetadata }>('/src/assets/images/
     </Fragment>
 
     <Fragment slot="subtitle">
-      <p>
-        IceNet is a deep learning sea ice forecasting system developed by an <a
-          class="hyperlink"
-          href="https://www.bas.ac.uk/media-post/artificial-intelligence-to-help-predict-arctic-sea-ice-loss/"
-          >international team and led by the British Antarctic Survey and The Alan Turing Institute</a
-        >. The original IceNet research model, published in <a
-          class="hyperlink"
-          href="https://www.nature.com/articles/s41467-021-25257-4"><b>Nature Communications</b></a
-        >, was trained on climate simulations and observational data to forecast the next 6 months of monthly-averaged
-        sea ice concentration maps. This version advanced the range of accurate sea ice forecasts, outperforming a
-        state-of-the-art dynamical model (ECMWF SEAS5) in seasonal forecasts of summer sea ice, particularly for extreme
-        sea ice events.
-      </p><br />
-      <p>
-        Since then, the IceNet team has focused on building an operational version of the model which forecasts on a
-        daily resolution. The <a class="hyperlink" href="https://www.github.com/tom-andersson/icenet-paper"
-          >original research code</a
-        > was refactored into <code>icenet</code> - <a class="hyperlink" href="https://github.com/icenet-ai/icenet"
-          >a library for operational forecasting</a
-        >. The <code>icenet</code> library can support further research efforts into AI-based operational sea ice forecasting.
-      </p><br />
-      <p>
-        In addition, several use cases and an ecosystem of service components are contained within this organization,
-        supporting execution and downstream analysis.
-      </p>
-      <p>
-        <br />
-        For further information about the team involved, please look at the <a
-          class="hyperlink"
-          href="https://www.bas.ac.uk/project/icenet/">project pages at BAS</a
-        > or <a
-          class="hyperlink"
-          href="https://www.turing.ac.uk/news/artificial-intelligence-help-predict-arctic-sea-ice-loss"
-          >The Alan Turing Institute</a
-        >.
-      </p>
+      <div class="intersect-once intersect-quarter motion-safe:md:opacity-0 motion-safe:md:intersect:animate-fade">
+        <p>
+          IceNet is a deep learning sea ice forecasting system developed by an
+          <a
+            class="hyperlink"
+            href="https://www.bas.ac.uk/media-post/artificial-intelligence-to-help-predict-arctic-sea-ice-loss/"
+          >
+            international team and led by the British Antarctic Survey and The Alan Turing Institute
+          </a>.
+          The original IceNet research model, published in
+          <a
+            class="hyperlink"
+            href="https://www.nature.com/articles/s41467-021-25257-4"
+          >
+            <b>Nature Communications</b>
+          </a>,
+          was trained on climate simulations and observational data to forecast the next 6 months of
+          monthly-averaged sea ice concentration maps. This version advanced the range of accurate sea
+          ice forecasts, outperforming a state-of-the-art dynamical model (ECMWF SEAS5) in seasonal
+          forecasts of summer sea ice, particularly for extreme sea ice events. <br><br>
+        </p>
+
+        <p>
+          Since then, the IceNet team has focused on building an operational version of the model which
+          forecasts on a daily resolution. The
+          <a class="hyperlink" href="https://www.github.com/tom-andersson/icenet-paper">
+            original research code
+          </a>
+          was refactored into <code>icenet</code> –
+          <a class="hyperlink" href="https://github.com/icenet-ai/icenet">
+            a library for operational forecasting
+          </a>.
+          The <code>icenet</code> library can support further research efforts into AI-based operational
+          sea ice forecasting. <br><br>
+        </p>
+
+        <p>
+          In addition, several use cases and an ecosystem of service components are contained within
+          this organisation, supporting execution and downstream analysis.
+        </p>
+
+        <p>
+          For further information about the team involved, please look at the
+          <a class="hyperlink" href="https://www.bas.ac.uk/project/icenet/">
+            project pages at BAS
+          </a>
+          or
+          <a
+            class="hyperlink"
+            href="https://www.turing.ac.uk/news/artificial-intelligence-help-predict-arctic-sea-ice-loss"
+          >
+            The Alan Turing Institute
+          </a>.
+        </p>
+      </div>
     </Fragment>
+
   </Hero>
 
   <!-- HighlightedPosts Widget ******* -->


### PR DESCRIPTION
As per title, a post announcing public accessibility of current BAS HPC run daily forecasts via the Polar Data Centre's RAMADDA instance.

<img width="1920" height="6474" alt="image" src="https://github.com/user-attachments/assets/f831058b-f797-4b35-a737-4dfbddf768f1" />
