### PR TITLE
Update actions.yaml to fix build issue

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -35,10 +35,11 @@ jobs:
             bash
           post-cleanup: 'all'
       - name: Fetch icenet and install repository and dependencies for docs
+        shell: bash -l {0}
         run: |
-          micromamba install -y -c conda-forge netcdf4=1.6.0
           eval "$(micromamba shell hook --shell bash)"
           micromamba activate base
+          micromamba install -y -c conda-forge netcdf4=1.6.0
           git clone https://github.com/icenet-ai/icenet.git
           cd icenet
           git submodule set-url icenet-notebooks https://github.com/icenet-ai/icenet-notebooks.git


### PR DESCRIPTION
using Claude Code

```
ERROR: Could not find a version that satisfies the requirement tensorflow<2.16 (from icenet)
ERROR: Ignored the following versions that require a different python version:
  0.10.7 Requires-Python >=3.9,<3.12; 1.0.0 Requires-Python >=3.9,<3.12
```

**Root cause:** `icenet` requires `tensorflow<2.16`, but tensorflow versions below 2.16 don't have wheels available for **Python 3.12**, which is what `pip` is picking up (note the system pip resolving `cp312` wheels throughout the log). Meanwhile, micromamba installed **Python 3.11** in the base environment — but `pip install .` is falling through to the *system* pip (Python 3.12) because the micromamba environment isn't properly activated before that command runs.

The key giveaway is this line:
```
Defaulting to user installation because normal site-packages is not writeable
```
This means pip is running outside the micromamba environment entirely.

**The fix** is to ensure the micromamba environment is activated before running `pip install`. The `eval` + `activate` commands don't persist across separate `run:` shell invocations. You need to either use the `shell` key with micromamba, or run everything in one properly activated subshell.

Here's the corrected step:

```yaml
- name: Fetch icenet and install repository and dependencies for docs
  shell: bash -l {0}
  run: |
    eval "$(micromamba shell hook --shell bash)"
    micromamba activate base
    micromamba install -y -c conda-forge netcdf4=1.6.0
    git clone https://github.com/icenet-ai/icenet.git
    cd icenet
    git submodule set-url icenet-notebooks https://github.com/icenet-ai/icenet-notebooks.git
    git submodule update --init
    pip install .
    cd docs
    pip install -r requirements.txt
    make html
    cd ../..
```

The key changes are:
1. **`shell: bash -l {0}`** — runs as a login shell so micromamba hooks are loaded
2. **Move the `eval` + `micromamba activate` to the top** of the same step where `pip install` runs, so they're in the same shell session
3. **Remove the separate `micromamba install` step** (or fold it in here after activation) so netcdf4 goes into the right environment

After activation, `pip` will resolve to Python 3.11 inside the micromamba environment, where `tensorflow<2.16` wheels are available.